### PR TITLE
Refactor/input

### DIFF
--- a/src/common/componentsV2/Atoms/Input/Input.tsx
+++ b/src/common/componentsV2/Atoms/Input/Input.tsx
@@ -11,6 +11,7 @@ type InputProps = {
   type?: string;
   placeholder?: string;
   isDisabled?: boolean;
+  hasError?: boolean;
   // let us pass an array of input attributes, eg: min, max, pattern, ...
   additionalAttributes?: Record<string, any>;
 };
@@ -23,6 +24,7 @@ const handleInputWrapping = (
     placeholder,
     isDisabled,
     onChange,
+    hasError,
     additionalAttributes,
     ...props
   }: InputProps
@@ -34,6 +36,7 @@ const handleInputWrapping = (
       placeholder={placeholder}
       disabled={isDisabled}
       onChange={onChange}
+      className={hasError ? "has-error" : ""}
       {...additionalAttributes}
       {...props}
     />

--- a/src/common/componentsV2/Atoms/Input/Input.tsx
+++ b/src/common/componentsV2/Atoms/Input/Input.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { StyledComponent } from "styled-components";
+
+import { IStyleableProps } from "../../../commonTypes";
+import { StyledInput } from "./styles";
+
+type InputProps = {
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  value?: string | number;
+  step?: number;
+  type?: string;
+  placeholder?: string;
+  isDisabled?: boolean;
+  // let us pass an array of input attributes, eg: min, max, pattern, ...
+  additionalAttributes?: Record<string, any>;
+};
+
+const handleInputWrapping = (
+  Component: StyledComponent<"input", any>,
+  {
+    value,
+    type = "text",
+    placeholder,
+    isDisabled,
+    onChange,
+    additionalAttributes,
+    ...props
+  }: InputProps
+) => {
+  return (
+    <Component
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      disabled={isDisabled}
+      onChange={onChange}
+      {...additionalAttributes}
+      {...props}
+    />
+  );
+};
+
+export const Input = (props: InputProps & IStyleableProps) =>
+  handleInputWrapping(StyledInput, props);

--- a/src/common/componentsV2/Atoms/Input/styles.ts
+++ b/src/common/componentsV2/Atoms/Input/styles.ts
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+import { stakenetTheme as theme } from "../../../../shell/theme/stakenetTheme";
+
+export type IStyledInputProps = {
+  isLoading?: boolean;
+  fontWeight?: number;
+  fullWidth?: boolean;
+  borderRadius?: string;
+};
+
+export const StyledInput = styled.input<IStyledInputProps>`
+  font-size: ${theme.paragraph.xl};
+  color: ${theme.colors.blue.lighter};
+  background-color: ${theme.colors.blue.dark};
+  width: 100%;
+  padding: 1.4rem;
+  border-width: 2px;
+  border-style: solid;
+  border-color: ${theme.colors.gray["medium-dark"]};
+  border-radius: ${theme.borderRadius.lg};
+
+  transition: border-color 300ms, color 300ms;
+
+  &::placeholder {
+    color: ${theme.colors.gray["medium-dark"]};
+  }
+
+  &:focus,
+  :focus-visible,
+  :focus-within {
+    outline: none;
+    color: ${theme.colors.white};
+    border-color: ${theme.colors.blue.light};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    color: ${theme.colors.gray["medium-dark"]};
+  }
+`;

--- a/src/common/componentsV2/Atoms/Input/styles.ts
+++ b/src/common/componentsV2/Atoms/Input/styles.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { stakenetTheme as theme } from "../../../../shell/theme/stakenetTheme";
+import { getHasError } from "../../../stylesV2/states";
 
 export type IStyledInputProps = {
   isLoading?: boolean;
@@ -36,5 +37,12 @@ export const StyledInput = styled.input<IStyledInputProps>`
   &:disabled {
     cursor: not-allowed;
     color: ${theme.colors.gray["medium-dark"]};
+  }
+
+  &.has-error {
+    ${getHasError};
+    &::placeholder {
+      ${getHasError};
+    }
   }
 `;

--- a/src/common/stylesV2/states.ts
+++ b/src/common/stylesV2/states.ts
@@ -1,0 +1,13 @@
+import { css } from "styled-components";
+import { stakenetTheme as theme } from "../../shell/theme/stakenetTheme";
+
+export const isDisabled = css`
+  cursor: not-allowed;
+  color: ${theme.colors.gray["medium-dark"]};
+  border-color: ${theme.colors.gray["medium-dark"]};
+`;
+
+export const getHasError = css`
+  color: ${theme.colors.red};
+  border-color: ${theme.colors.red};
+`;

--- a/src/shell/theme/stakenetTheme.ts
+++ b/src/shell/theme/stakenetTheme.ts
@@ -13,6 +13,7 @@ export interface IStakenetTheme extends DefaultTheme {
       "medium-dark": string;
     };
     white: string;
+    red: string;
     gray: {
       darker: string;
       dark: string;
@@ -88,6 +89,7 @@ export const stakenetTheme: IStakenetTheme = {
       lightest: "#1D96EC",
     },
     white: "#FFFFFF",
+    red: "#BF2C44",
     gray: {
       darker: "#7377A514",
       dark: "#7377A529",

--- a/src/stories/Atoms/Inputs/Input.stories.tsx
+++ b/src/stories/Atoms/Inputs/Input.stories.tsx
@@ -27,3 +27,10 @@ Disabled.args = {
     pattern: "[0-9]",
   },
 };
+
+export const WithError = Template.bind({});
+WithError.args = {
+  placeholder: "0.0",
+  type: "text",
+  hasError: true,
+};

--- a/src/stories/Atoms/Inputs/Input.stories.tsx
+++ b/src/stories/Atoms/Inputs/Input.stories.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Input } from "../../../common/componentsV2/Atoms/Input/Input";
+
+export default {
+  title: "Atoms/Inputs/Input",
+  component: Input,
+} as ComponentMeta<typeof Input>;
+
+const Template: ComponentStory<typeof Input> = (args) => <Input {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  placeholder: "0.0",
+  type: "text",
+  additionalAttributes: {},
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  type: "number",
+  placeholder: "0.0",
+  isDisabled: true,
+  additionalAttributes: {
+    min: 1,
+    max: 30,
+    pattern: "[0-9]",
+  },
+};


### PR DESCRIPTION
create the input matching the theme mockups
simplify props passed, let the possibility to pass an object of additional html attributes for the input (max, steps, min, pattern and so on)

**EDIT : I've closed this PR, im awaiting we create a develop branch, so i can override the current code, will submit something clean when we got that develop branch**