### PR TITLE
Feature/add tests for amounts bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "web3": "^1.6.1"
   },
   "devDependencies": {
-    "babel-loader": "8.1.0",
-    "react-error-overlay": "6.0.9",
     "@react-theming/storybook-addon": "^1.1.5",
     "@storybook/addon-actions": "^6.4.18",
     "@storybook/addon-essentials": "^6.4.18",
@@ -41,6 +39,7 @@
     "@storybook/theming": "^6.4.18",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
+    "@testing-library/react-hooks": "^7.0.2",
     "@testing-library/user-event": "^12.1.10",
     "@types/jest": "^26.0.15",
     "@types/lodash": "^4.14.178",
@@ -50,6 +49,7 @@
     "@types/styled-components": "^5.1.16",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
+    "babel-loader": "8.1.0",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
@@ -58,6 +58,7 @@
     "husky": "^7.0.4",
     "lint-staged": "^12.3.3",
     "prettier": "^2.5.1",
+    "react-error-overlay": "6.0.9",
     "web-vitals": "^1.0.1"
   },
   "scripts": {

--- a/src/__tests__/functions/stringHelper.test.ts
+++ b/src/__tests__/functions/stringHelper.test.ts
@@ -1,0 +1,46 @@
+import { replaceCharsToHaveOnlyDotOrStringInIt } from "../../helpers/stringHelper";
+
+const testCases = [
+  {
+    providedValue: ",37!",
+    expectedResult: "37",
+  },
+  {
+    providedValue: ".,37!",
+    expectedResult: ".37",
+  },
+  {
+    providedValue: "0,7",
+    expectedResult: "07",
+  },
+  {
+    providedValue: "-7",
+    expectedResult: "7",
+  },
+  {
+    providedValue: "-7.",
+    expectedResult: "7.",
+  },
+  {
+    providedValue: "+7",
+    expectedResult: "7",
+  },
+  {
+    providedValue: ".07.",
+    expectedResult: ".07",
+  },
+  {
+    providedValue: ".07.",
+    expectedResult: ".07",
+  },
+];
+
+describe("The replaceCharsToHaveOnlyDotOrStringInIt method", () => {
+  testCases.forEach((testCase) => {
+    it(`should keep only <${testCase.expectedResult}> when provided <${testCase.providedValue}>`, () => {
+      expect(
+        replaceCharsToHaveOnlyDotOrStringInIt(testCase.providedValue)
+      ).toBe(testCase.expectedResult);
+    });
+  });
+});

--- a/src/__tests__/functions/stringHelper.test.ts
+++ b/src/__tests__/functions/stringHelper.test.ts
@@ -33,6 +33,18 @@ const testCases = [
     providedValue: ".07.",
     expectedResult: ".07",
   },
+  {
+    providedValue: "..4",
+    expectedResult: ".4",
+  },
+  {
+    providedValue: ".4.",
+    expectedResult: ".4",
+  },
+  {
+    providedValue: ".4.3",
+    expectedResult: ".43",
+  },
 ];
 
 describe("The replaceCharsToHaveOnlyDotOrStringInIt method", () => {

--- a/src/__tests__/hooks/useAmountInput.test.ts
+++ b/src/__tests__/hooks/useAmountInput.test.ts
@@ -1,0 +1,120 @@
+import useAmountInput from "../../modules/Home/useAmountInput";
+import { act, renderHook, RenderResult } from "@testing-library/react-hooks";
+
+describe("useAmountInput hook", () => {
+  let hookInstance: RenderResult<any> | { current: {} };
+
+  beforeEach(() => {
+    const { result } = renderHook(() =>
+      //@ts-ignore
+      useAmountInput("", 2, 2, 2, 2, [], false, () => true)
+    );
+    hookInstance = result;
+  });
+
+  afterEach(() => {
+    hookInstance = { current: {} };
+  });
+
+  describe("default hook state", () => {
+    it("should have empty string as value for state amountIn", () => {
+      expect(hookInstance.current.amountIn).toBe("");
+    });
+
+    it("should have empty string as value for state amountOut", () => {
+      expect(hookInstance.current.amountOut).toBe("");
+    });
+
+    it("should have false as value for sate isNotEnoughBalance", () => {
+      expect(hookInstance.current.isNotEnoughBalance).toBe(false);
+    });
+
+    it("getParsedAmountIn should return number 0 when amountIn is empty", () => {
+      const parsedAmount = hookInstance.current.getParsedAmountIn();
+
+      expect(hookInstance.current.amountIn).toBe("");
+      expect(typeof parsedAmount === "number").toBe(true);
+      expect(parsedAmount).toBe(0);
+    });
+
+    it("getParsedAmountOut should return number 0 when amountIn is empty", () => {
+      const parsedAmount = hookInstance.current.getParsedAmountOut();
+
+      expect(hookInstance.current.amountIn).toBe("");
+      expect(typeof parsedAmount === "number").toBe(true);
+      expect(parsedAmount).toBe(0);
+    });
+  });
+
+  describe("when updating amountIn on onAmountInChange", () => {
+    it("should be a whole number", () => {
+      act(() => {
+        hookInstance.current.onAmountInChange("32");
+      });
+      expect(hookInstance.current.amountIn).toBe("32");
+      expect(hookInstance.current.getParsedAmountIn()).toBe(32);
+      expect(hookInstance.current.getParsedAmountOut()).toBe(32);
+    });
+
+    it("should be empty and parsedFunctions returns 0", () => {
+      act(() => {
+        hookInstance.current.setAmountIn("32");
+        hookInstance.current.setAmountOut("32");
+        hookInstance.current.onAmountInChange("");
+      });
+      expect(hookInstance.current.amountIn).toBe("");
+      expect(hookInstance.current.getParsedAmountIn()).toBe(0);
+      expect(hookInstance.current.getParsedAmountOut()).toBe(0);
+    });
+
+    it("should be a decimal number", () => {
+      act(() => {
+        hookInstance.current.onAmountInChange("32.4");
+      });
+      expect(hookInstance.current.amountIn).toBe("32.4");
+      expect(hookInstance.current.getParsedAmountIn()).toBe(32.4);
+      expect(hookInstance.current.getParsedAmountOut()).toBe(32.4);
+    });
+
+    it("should return number 0 when writing first with a dot", () => {
+      act(() => {
+        hookInstance.current.onAmountInChange(".");
+      });
+      expect(hookInstance.current.amountIn).toBe(".");
+      expect(hookInstance.current.getParsedAmountIn()).toBe(0);
+      expect(hookInstance.current.getParsedAmountOut()).toBe(0);
+    });
+
+    it("should be 0 and decimal number", () => {
+      act(() => {
+        hookInstance.current.onAmountInChange(".34");
+      });
+      expect(hookInstance.current.amountIn).toBe(".34");
+      expect(hookInstance.current.getParsedAmountIn()).toBe(0.34);
+      expect(hookInstance.current.getParsedAmountOut()).toBe(0.34);
+    });
+
+    it("should be 0 and decimal number", () => {
+      act(() => {
+        hookInstance.current.onAmountInChange("7.");
+      });
+      expect(hookInstance.current.amountIn).toBe("7.");
+      console.log(hookInstance.current.getParsedAmountIn());
+      expect(hookInstance.current.getParsedAmountIn()).toBe(7);
+      expect(hookInstance.current.getParsedAmountOut()).toBe(7);
+    });
+
+    it("should be parsed correctly with big numbers", () => {
+      act(() => {
+        hookInstance.current.onAmountInChange("99999999999999999999999999");
+      });
+      expect(hookInstance.current.amountIn).toBe("99999999999999999999999999");
+      expect(hookInstance.current.getParsedAmountIn()).toBe(
+        99999999999999999999999999
+      );
+      expect(hookInstance.current.getParsedAmountOut()).toBe(
+        99999999999999999999999999
+      );
+    });
+  });
+});

--- a/src/helpers/numberHelper.ts
+++ b/src/helpers/numberHelper.ts
@@ -3,7 +3,7 @@
  * @param stringNumber
  * @return the parsed number
  */
-export const parseStringToNumber = (stringNumber: string) => {
+export const parseStringToNumber = (stringNumber: string): number => {
   if (Number.isNaN(Number(stringNumber))) {
     return 0;
   }

--- a/src/helpers/stringHelper.ts
+++ b/src/helpers/stringHelper.ts
@@ -4,3 +4,11 @@ export const isEmpty = (value: string): boolean =>
   value === "null" ||
   value === null ||
   value === "";
+
+/**
+ * Will replace unwanted chars from the value string (only 0-9 and .(dot) authorized)
+ * @param value - the string to verify
+ * @return the clean string
+ */
+export const replaceCharsToHaveOnlyDotOrStringInIt = (value: string): string =>
+  value.replace(/[^0-9.]/g, "").replace(/(\..*)\./g, "$1");

--- a/src/modules/Home/MainContent.tsx
+++ b/src/modules/Home/MainContent.tsx
@@ -10,6 +10,7 @@ import { Input } from "../../common/components/Atoms/Input/Input";
 import { ETHEREUM, GOERLI, POLYGON } from "../../common/constants";
 import { ChainResponseDto } from "../../common/dtos";
 import { getOnlyNumbersAndAllowDotPattern } from "../../helpers/regexHelper";
+import { replaceCharsToHaveOnlyDotOrStringInIt } from "../../helpers/stringHelper";
 import { stakenetTheme as theme } from "../../shell/theme/stakenetTheme";
 
 const getFromChains = (chains: ChainResponseDto[]) => {
@@ -105,17 +106,9 @@ const MainContent = ({
   const handleAmountInChange = (
     evt: React.ChangeEvent<HTMLInputElement>
   ): void => {
-    const value = replaceUnwantedStringChars(evt.target.value);
+    const value = replaceCharsToHaveOnlyDotOrStringInIt(evt.target.value);
     onAmountChange(value);
   };
-
-  /**
-   * Will replace unwanted chars from the value string (only 0-9 and .(dot) authorized)
-   * @param value - the string to verify
-   * @return the clean string
-   */
-  const replaceUnwantedStringChars = (value: string): string =>
-    value.replace(/[^0-9.]/g, "").replace(/(\..*)\./g, "$1");
 
   return (
     <ContainerCard>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,6 +3648,17 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^11.1.0":
   version "11.2.7"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
@@ -4033,7 +4044,7 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/react-dom@^17.0.1", "@types/react-dom@^17.0.11":
+"@types/react-dom@>=16.9.0", "@types/react-dom@^17.0.1", "@types/react-dom@^17.0.11":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
   integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
@@ -4061,6 +4072,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.0":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
@@ -4068,7 +4086,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.0":
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.0":
   version "17.0.39"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
   integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
@@ -16111,6 +16129,13 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@6.0.10, react-error-overlay@^6.0.9:
   version "6.0.10"


### PR DESCRIPTION
add tests for amountIn/amountOut values and  getParsedAmountIn() / getParsedAmountOut()
add tests for the function that validate the input value at first level to ensure we get only numbers chars and a  single dot (same as a input type number would do)

install module from react-testing-library for hooks testing

NB: This is the last PR regarding the input.